### PR TITLE
Feat/헤더 레이아웃

### DIFF
--- a/src/components/feedHeader/index.jsx
+++ b/src/components/feedHeader/index.jsx
@@ -4,38 +4,58 @@ import { Link } from 'react-router-dom';
 import urlCopy from 'assets/images/icons/ic_Link.svg';
 import kakaotalk from 'assets/images/icons/ic_Kakaotalk.svg';
 import facebook from 'assets/images/icons/ic_Facebook.svg';
+import { getSubject } from 'api/subjects';
+import { useCallback, useEffect, useState } from 'react';
 
 const style = {
   filter: 'invert(100%) sepia(0%) saturate(0%) hue-rotate(192deg) brightness(107%) contrast(105%)',
 };
 
-const FeedHeader = () => (
-  <div className='fixed'>
-    <div className='flex flex-col items-center relative'>
-      <div className='w-screen overflow-hidden flex justify-center'>
-        <img className='min-w-[906px] md:min-w-[1200px]' src={banner} alt='Banner_Image' />
-      </div>
-      <div className='flex flex-col items-center gap-3 absolute top-[40px] md:top-[50px]'>
-        <Link to='/'>
-          <img className='max-w-[124px] md:max-w-[170px]' src={logo} alt='Logo' />
-        </Link>
-        {/* <img className='rounded-full max-w-[104px] max-h-[104px] md:max-w-[136px] md:max-h-[136px]' src={profileImg} alt='Banner' /> */}
-        {/* 프로필 이미지입니다. 이미지 src는 서버에서 데이터 요청 후 반영할 예정입니다. */}
-        <div className='font-normal text-2xl/[30px] md:text-[32px]/[40px]'>이름</div>
-        <div className='flex gap-3'>
-          <div className='flex justify-center items-center w-10 h-10 rounded-full bg-[#542F1A]'>
-            <img className='w-[18px] h-[18px]' style={style} src={urlCopy} alt='url_copy' />
-          </div>
-          <div className='flex justify-center items-center w-10 h-10 rounded-full bg-[#FEE500]'>
-            <img className='w-[18px] h-[18px]' src={kakaotalk} alt='kakaotalk_share' />
-          </div>
-          <div className='flex justify-center items-center w-10 h-10 rounded-full bg-[#1877F2]'>
-            <img className='w-[18px] h-[18px]' style={style} src={facebook} alt='facebook_share' />
+const FeedHeader = () => {
+  // 프로필 사진과 이름을 getSubject 함수로 불러옵니다.
+  // 테스트용으로 만들었으며 차후에 id 값으로 고유한 이미지와 이름을 불러오도록 수정해야합니다.
+
+  const [name, setName] = useState('');
+  const [profileImg, setProfileImg] = useState('');
+
+  const handleLoad = useCallback(async () => {
+    const { results } = await getSubject();
+
+    setProfileImg(results[0].imageSource);
+    setName(results[0].name);
+  }, []);
+
+  useEffect(() => {
+    handleLoad();
+  }, [handleLoad]);
+
+  return (
+    <div className='fixed'>
+      <div className='flex flex-col items-center relative'>
+        <div className='w-screen overflow-hidden flex justify-center'>
+          <img className='min-w-[906px] md:min-w-[1200px]' src={banner} alt='Banner_Image' />
+        </div>
+        <div className='flex flex-col items-center gap-3 absolute top-[40px] md:top-[50px]'>
+          <Link to='/'>
+            <img className='max-w-[124px] md:max-w-[170px]' src={logo} alt='Logo' />
+          </Link>
+          <img className='rounded-full max-w-[104px] max-h-[104px] md:max-w-[136px] md:max-h-[136px]' src={profileImg} alt='Banner' />
+          <div className='font-normal text-2xl/[30px] md:text-[32px]/[40px]'>{name}</div>
+          <div className='flex gap-3'>
+            <div className='flex justify-center items-center w-10 h-10 rounded-full bg-[#542F1A]'>
+              <img className='w-[18px] h-[18px]' style={style} src={urlCopy} alt='url_copy' />
+            </div>
+            <div className='flex justify-center items-center w-10 h-10 rounded-full bg-[#FEE500]'>
+              <img className='w-[18px] h-[18px]' src={kakaotalk} alt='kakaotalk_share' />
+            </div>
+            <div className='flex justify-center items-center w-10 h-10 rounded-full bg-[#1877F2]'>
+              <img className='w-[18px] h-[18px]' style={style} src={facebook} alt='facebook_share' />
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default FeedHeader;

--- a/src/components/feedHeader/index.jsx
+++ b/src/components/feedHeader/index.jsx
@@ -5,6 +5,10 @@ import urlCopy from 'assets/images/icons/ic_Link.svg';
 import kakaotalk from 'assets/images/icons/ic_Kakaotalk.svg';
 import facebook from 'assets/images/icons/ic_Facebook.svg';
 
+const style = {
+  filter: 'invert(100%) sepia(0%) saturate(0%) hue-rotate(192deg) brightness(107%) contrast(105%)',
+};
+
 const FeedHeader = () => (
   <div className='fixed'>
     <div className='flex flex-col items-center relative'>
@@ -19,9 +23,15 @@ const FeedHeader = () => (
         {/* 프로필 이미지입니다. 이미지 src는 서버에서 데이터 요청 후 반영할 예정입니다. */}
         <div className='font-normal text-2xl/[30px] md:text-[32px]/[40px]'>이름</div>
         <div className='flex gap-3'>
-          <img src={urlCopy} alt='url_copy' />
-          <img src={kakaotalk} alt='kakaotalk_share' />
-          <img src={facebook} alt='facebook_share' />
+          <div className='flex justify-center items-center w-10 h-10 rounded-full bg-[#542F1A]'>
+            <img className='w-[18px] h-[18px]' style={style} src={urlCopy} alt='url_copy' />
+          </div>
+          <div className='flex justify-center items-center w-10 h-10 rounded-full bg-[#FEE500]'>
+            <img className='w-[18px] h-[18px]' src={kakaotalk} alt='kakaotalk_share' />
+          </div>
+          <div className='flex justify-center items-center w-10 h-10 rounded-full bg-[#1877F2]'>
+            <img className='w-[18px] h-[18px]' style={style} src={facebook} alt='facebook_share' />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/feedHeader/index.jsx
+++ b/src/components/feedHeader/index.jsx
@@ -1,0 +1,31 @@
+import banner from 'assets/images/img_Banner.svg';
+import logo from 'assets/images/img_Logo.svg';
+import { Link } from 'react-router-dom';
+import urlCopy from 'assets/images/icons/ic_Link.svg';
+import kakaotalk from 'assets/images/icons/ic_Kakaotalk.svg';
+import facebook from 'assets/images/icons/ic_Facebook.svg';
+
+const FeedHeader = () => (
+  <div className='fixed'>
+    <div className='flex flex-col items-center relative'>
+      <div className='w-screen overflow-hidden flex justify-center'>
+        <img className='min-w-[906px] md:min-w-[1200px]' src={banner} alt='Banner_Image' />
+      </div>
+      <div className='flex flex-col items-center gap-3 absolute top-[40px] md:top-[50px]'>
+        <Link to='/'>
+          <img className='max-w-[124px] md:max-w-[170px]' src={logo} alt='Logo' />
+        </Link>
+        {/* <img className='rounded-full max-w-[104px] max-h-[104px] md:max-w-[136px] md:max-h-[136px]' src={profileImg} alt='Banner' /> */}
+        {/* 프로필 이미지입니다. 이미지 src는 서버에서 데이터 요청 후 반영할 예정입니다. */}
+        <div className='font-normal text-2xl/[30px] md:text-[32px]/[40px]'>이름</div>
+        <div className='flex gap-3'>
+          <img src={urlCopy} alt='url_copy' />
+          <img src={kakaotalk} alt='kakaotalk_share' />
+          <img src={facebook} alt='facebook_share' />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default FeedHeader;

--- a/src/pages/Answer/index.jsx
+++ b/src/pages/Answer/index.jsx
@@ -1,3 +1,5 @@
-const Answer = () => <h1>답변 페이지입니다.</h1>;
+import FeedHeader from 'components/feedHeader';
+
+const Answer = () => <FeedHeader />;
 
 export default Answer;


### PR DESCRIPTION
## :writing_hand: Description

답변하기 피드와 질문 리스트 피드 헤더부분 레이아웃 작업에 관한 PR입니다.


주요 변경 사항:

각 피드에 공통적으로 사용되는 헤더 부분 레이아웃을 구현했습니다.
배너 이미지, 로고, 프로필 사진, 이름, url복사 및 sns 공유 버튼을 추가했습니다.
로고 클릭시 루트 페이지로 이동합니다.
프로필 사진과 이름의 경우 getSubject 함수를 통해 데이터를 불러오는 방식으로 테스트 했습니다.


미완성된 기능:

링크 버튼 클릭 시 url이 클립보드에 저장되고 잠시동안 토스트 가 화면에 보이는 기능을 구현해야합니다.


추후 작업:

url 버튼 클릭 시 클립보드에 url이 복사되고 복사되었다는 안내문구가 적힌 토스트를 보여주는 작업을 진행할 예정입니다.

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `epic/` 에픽, `feat/` 피쳐, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
