### PR TITLE
Feat/답변 상태 표시

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "cra-template": "1.2.0",
+        "prop-types": "^15.8.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "cra-template": "1.2.0",
+    "prop-types": "^15.8.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.0.2",

--- a/src/components/AnswerStatus/index.jsx
+++ b/src/components/AnswerStatus/index.jsx
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types';
+
+const AnswerStatus = ({ answer }) => <div>{answer ? <span>답변 완료</span> : <span>미답변</span>}</div>;
+
+AnswerStatus.propTypes = {
+  answer: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    questionId: PropTypes.number.isRequired,
+    content: PropTypes.string.isRequired,
+    isRejected: PropTypes.bool.isRequired,
+    createdAt: PropTypes.string.isRequired,
+  }),
+};
+
+export default AnswerStatus;


### PR DESCRIPTION
## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->
피드 페이지와 답변 페이지에서 공통으로 사용할 답변 상태 표시 컴포넌트에 관한 PR입니다.
CSS는 추후 작업 예정입니다.

prop 타입 정의를 위한 prop-types 모듈 설치하였습니다.

테스트는 답변 페이지에서 간단하게 진행했고, 코드는 다음과 같습니다.
```js
import { useState, useEffect } from 'react';
import { useParams } from 'react-router-dom';
import { getQuestionBySubjectId } from 'api/questions';
import AnswerStatus from 'components/AnswerStatus';

const Answer = () => {
  const { id: subjectId } = useParams();
  const [questionList, setQuestionList] = useState([]);

  useEffect(() => {
    const fetchQuestions = async () => {
      const response = await getQuestionBySubjectId(subjectId);
      if (response.results) {
        setQuestionList(response.results);
      }
    };

    fetchQuestions();
  }, [subjectId]);

  return (
    <>
      <div>
        <ul>
          {questionList.map((question) => (
            <li key={question.id}>
              <AnswerStatus answer={question.answer} />
            </li>
          ))}
        </ul>
      </div>
    </>
  );
};

export default Answer;

```

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `epic/` 에픽, `feat/` 피쳐, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
